### PR TITLE
Fix bug (infinite loop) in getFilePath function

### DIFF
--- a/src/SpriteReader.cpp
+++ b/src/SpriteReader.cpp
@@ -339,6 +339,9 @@ std::string getFilePath(const std::string& english_name) {
         } else if (english_name.substr(i, 2) == ". ") {
             file_name += '-';
             i += 2;
+        } else {
+            // skip the character
+            ++i;
         }
     }
     file_path.append(file_name);


### PR DESCRIPTION
Fix bug (infinite loop) in getFilePath function by skipping unexpected characters

The `getFilePath` function in `src/SpriteReader.cpp` was introduced to convert English names of Pokemon into file paths. However, it contained a bug that caused an infinite loop when encountering unexpected characters in the Pokemon name.

This PR addresses the issue by adding logic to skip unexpected characters, ensuring that the function correctly processes the name and constructs the file path without entering an infinite loop.
