### PR TITLE
Optimize Dockerfile with cache mounts for faster builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,13 @@ COPY include include
 COPY src src
 
 WORKDIR /usr/src/app/build
-RUN cmake ..
-RUN make
+RUN --mount=type=cache,target=/usr/src/app/build,sharing=locked \
+    cmake ..
+RUN --mount=type=cache,target=/usr/src/app/build,sharing=locked \
+    make -C /usr/src/app/build
+RUN --mount=type=cache,target=/usr/src/app/build,sharing=locked \
+    cp /usr/src/app/build/pokemon /tmp/pokemon
+RUN mv /tmp/pokemon /usr/src/app/build/pokemon
 
 CMD ["./pokemon"]
 


### PR DESCRIPTION
This PR optimizes the Dockerfile by adding cache mounts to the `cmake` and `make` commands. This change aims to significantly speed up the build process by leveraging Docker's build cache more effectively.

### Changes Made:
1. **Cache Mounts in `cmake` and `make` Commands:**
   - Added `--mount=type=cache,target=/usr/src/app/build,sharing=locked` to the `cmake` and `make` commands to utilize Docker's build cache.
   - This optimization ensures that intermediate build artifacts are cached, reducing build times for subsequent builds.

2. **Move Built Executable:**
   - Moved the built executable to `/usr/src/app/build` to ensure it is correctly placed in the final image.

### Benefits:
- **Faster Build Times:** By caching intermediate build artifacts, the build process will be significantly faster, especially for subsequent builds.

### Testing:
- Built the Docker image locally to verify that the changes work as expected.
- Confirmed that the application runs correctly after the build.
