### PR TITLE
Replace [] Indexing with .at() for Safety

### DIFF
--- a/src/DataReader.cpp
+++ b/src/DataReader.cpp
@@ -115,7 +115,7 @@ std::vector<GymLeader> readGymLeadersFromCSV(
 
             if(!pokemon_token.empty()) {
 
-                std::shared_ptr<Pokemon> pokemon { pokemon_map[pokemon_token]->clone() };
+                std::shared_ptr<Pokemon> pokemon { pokemon_map.at(pokemon_token)->clone() };
 
                 if(pokemon)
                     pokemons.push_back(pokemon);

--- a/src/FightUtils.cpp
+++ b/src/FightUtils.cpp
@@ -9,7 +9,7 @@ bool isOpponentMaster(Trainer& opponent) {
 void updatePokemonIndex(int& index, std::vector<std::shared_ptr<Pokemon>>& pokemon_list) {
 
     int list_lenght { static_cast<int>(pokemon_list.size()) };
-    while(index < list_lenght - 1 && pokemon_list[index]->getCurrentHp() <= 0) {
+    while(index < list_lenght - 1 && pokemon_list.at(index)->getCurrentHp() <= 0) {
         index++;
     }
     if(index >= list_lenght) {

--- a/src/SpriteReader.cpp
+++ b/src/SpriteReader.cpp
@@ -55,7 +55,7 @@ int getDigit(const wchar_t c) {
 /// @param i The index of the character to check.
 /// @return true if the character at index i is an ANSI escape.
 bool isAnsiEsc(const std::wstring& s, size_t& i)  {
-    if (i < s.size() && s[i] == '\x1b')  {
+    if (i < s.size() && s.at(i) == '\x1b')  {
         ++i;
         return true;
     }
@@ -64,7 +64,7 @@ bool isAnsiEsc(const std::wstring& s, size_t& i)  {
 
 std::optional<std::pair<size_t, Item>> extractSpaceOrSquare(const std::wstring& s, size_t i) {
     Item item;
-    const wchar_t& c { s[i] };
+    const wchar_t& c { s.at(i) };
 
     if (c == ' ') {
         item = Item::Space;
@@ -104,12 +104,12 @@ std::optional<std::pair<size_t, RGB>> parseRGB(const std::wstring& s, size_t i) 
         c = 0; // initialize at zero
         size_t num_digits {};
         for (size_t k {}; k < N && (start + k) < s.size(); ++k) {
-            int digit = getDigit(s[start + k]);
+            int digit = getDigit(s.at(start + k));
             if (digit != -1) {
                 ++num_digits;
                 c *= 10; // base 10 numbers
                 c += digit;
-            } else if (j == N - 1 || s[start + k] == SEP) {
+            } else if (j == N - 1 || s.at(start + k) == SEP) {
                 // the last rgb component has ended or a seperator was reached
                 break;
             } else {
@@ -125,7 +125,7 @@ std::optional<std::pair<size_t, RGB>> parseRGB(const std::wstring& s, size_t i) 
             // invalid uint8 value
             return std::nullopt;
         }
-        if (j != N - 1 && s[start + num_digits] != SEP) {
+        if (j != N - 1 && s.at(start + num_digits) != SEP) {
             // the separator is missing before the next value
             return std::nullopt;
         }
@@ -151,14 +151,14 @@ std::optional<std::pair<std::pair<size_t, RGB>, Item>> extractColor(const std::w
         auto parsed = parseRGB(s, i + 6);
         if (!parsed.has_value()) return std::nullopt;
         i = parsed.value().first;
-        if (i >= s.size() || s[i] != SET_TEXT_ATTRIBUTES) return std::nullopt;
+        if (i >= s.size() || s.at(i) != SET_TEXT_ATTRIBUTES) return std::nullopt;
         return std::make_pair(std::make_pair(i + 1, parsed.value().second), Item::FgColor);
     } else if (s.substr(i, 6) == L"[48;2;") {
         // background color
         auto parsed = parseRGB(s, i + 6);
         if (!parsed.has_value()) return std::nullopt;
         i = parsed.value().first;
-        if (i >= s.size() || s[i] != SET_TEXT_ATTRIBUTES) return std::nullopt;
+        if (i >= s.size() || s.at(i) != SET_TEXT_ATTRIBUTES) return std::nullopt;
         return std::make_pair(std::make_pair(i + 1, parsed.value().second), Item::BgColor);
     } else {
         // unknown content
@@ -259,11 +259,11 @@ std::vector<std::vector<Color>> convertToColorGrid(const std::vector<std::pair<s
             switch (elem)
             {
             case Item::FgColor:
-                fg_color = Color::RGB(colors[colorIndex].r, colors[colorIndex].g, colors[colorIndex].b);
+                fg_color = Color::RGB(colors.at(colorIndex).r, colors.at(colorIndex).g, colors.at(colorIndex).b);
                 ++colorIndex;
                 break;
             case Item::BgColor:
-                bg_color = Color::RGB(colors[colorIndex].r, colors[colorIndex].g, colors[colorIndex].b);
+                bg_color = Color::RGB(colors.at(colorIndex).r, colors.at(colorIndex).g, colors.at(colorIndex).b);
                 ++colorIndex;
                 break;
             case Item::ColorReset:
@@ -301,14 +301,14 @@ Component createSpriteComponent(const std::vector<std::vector<Color>>& grid) {
     for (size_t y {}; (y + 1) < grid.size(); y += 2) {
         Elements line;
         line.reserve(
-            grid[y].size() < grid[y + 1].size() ?
-            grid[y].size() : grid[y + 1].size()
+            grid.at(y).size() < grid.at(y + 1).size() ?
+            grid.at(y).size() : grid.at(y + 1).size()
         );
-        for (size_t x {}; x < grid[y].size() && x < grid[y + 1].size(); ++x) {
+        for (size_t x {}; x < grid.at(y).size() && x < grid.at(y + 1).size(); ++x) {
             line.push_back(
                 text("▀")
-                | color(grid[y][x])
-                | bgcolor(grid[y + 1][x])
+                | color(grid.at(y).at(x))
+                | bgcolor(grid.at(y + 1).at(x))
             );
         }
         array.emplace_back(hbox(std::move(line)));
@@ -326,7 +326,7 @@ std::string getFilePath(const std::string& english_name) {
     std::string file_name {};
     size_t i {};
     while (i < english_name.size()) {
-        const char c = english_name[i];
+        const char c = english_name.at(i);
         if (std::isalnum(c)) {
             file_name += std::tolower(c);
             ++i;

--- a/src/Trainer.cpp
+++ b/src/Trainer.cpp
@@ -42,7 +42,7 @@ int Player::getDefeats()    const   { return defeats; }
 int Player::getNbPotions()  const   { return nb_potions; }
 
 void Player::swapPokemons(int index1, int index2) {
-    std::swap(pokemons[index1], pokemons[index2]);
+    std::swap(pokemons.at(index1), pokemons.at(index2));
 }
 
 void Player::Defeated() { setDefeats(getDefeats() + 1); }

--- a/src/ui/Fight.cpp
+++ b/src/ui/Fight.cpp
@@ -18,7 +18,7 @@ void opponentTurn(bool& is_player_turn, std::vector<std::shared_ptr<Pokemon>>& p
         if(opponent_pokemon->getCurrentHp() > 0) {
             std::shared_ptr<Pokemon> target {};
             if(player_index < static_cast<int>(player_pokemons.size())){
-                target = player_pokemons[player_index];
+                target = player_pokemons.at(player_index);
             }
             if(target->getCurrentHp() > 0) {
                 float multiplicator { getDamagesMultiplicator(opponent_pokemon, target) };
@@ -79,7 +79,7 @@ void Fight(ftxui::ScreenInteractive& screen, Player& player, Trainer& opponent) 
             
             std::vector<Element> visible_logs;
             for (int i = start_index; i < log_size; ++i) {
-                visible_logs.push_back(fight_logs[i]);
+                visible_logs.push_back(fight_logs.at(i));
             }
     
             return vbox(visible_logs) | flex | size(HEIGHT, LESS_THAN, 8);
@@ -103,16 +103,16 @@ void Fight(ftxui::ScreenInteractive& screen, Player& player, Trainer& opponent) 
             std::shared_ptr<Pokemon> target {};
 
             if(opponent_index < static_cast<int>(opponent_pokemons.size())){
-                target = opponent_pokemons[opponent_index];
+                target = opponent_pokemons.at(opponent_index);
             }
 
             if(target->getCurrentHp() > 0) {
-                float multiplicator { getDamagesMultiplicator(player_pokemons[player_index], target) };
+                float multiplicator { getDamagesMultiplicator(player_pokemons.at(player_index), target) };
                 // Pokemon masters deal +25% damages 
                 if(is_master) { multiplicator *= 1.25; }
-                int damage { static_cast<int>(multiplicator * player_pokemons[player_index]->getAttackDamage()) };
+                int damage { static_cast<int>(multiplicator * player_pokemons.at(player_index)->getAttackDamage()) };
                 target->takeDamage(damage);
-                fight_logs.push_back(text(player_pokemons[player_index]->getName() + " does " + std::to_string(damage) + " damages to " + target->getName()));
+                fight_logs.push_back(text(player_pokemons.at(player_index)->getName() + " does " + std::to_string(damage) + " damages to " + target->getName()));
                 
                 screen.PostEvent(Event::Custom);
 
@@ -130,7 +130,7 @@ void Fight(ftxui::ScreenInteractive& screen, Player& player, Trainer& opponent) 
             
             is_player_turn = false;
 
-            opponentTurn(is_player_turn, player_pokemons, player_index, opponent_pokemons[opponent_index], player, opponent, fight_logs, screen);
+            opponentTurn(is_player_turn, player_pokemons, player_index, opponent_pokemons.at(opponent_index), player, opponent, fight_logs, screen);
         }
     }, ButtonOption::Animated());
 
@@ -141,15 +141,15 @@ void Fight(ftxui::ScreenInteractive& screen, Player& player, Trainer& opponent) 
             return vbox({
                 text(player.getName() + " - " + std::to_string(player.getNbPotions()) + " potion(s)"),
                 separatorDouble(),
-                player_pokemons[player_index]->getSprite()->Render(),
+                player_pokemons.at(player_index)->getSprite()->Render(),
                 text (
-                    "Current Pokemon: " + player_pokemons[player_index]->getName() + " - "
-                    + std::to_string(player_pokemons[player_index]->getCurrentHp()) + "/" 
-                    + std::to_string(player_pokemons[player_index]->getBaseHp()) + " HP"
+                    "Current Pokemon: " + player_pokemons.at(player_index)->getName() + " - "
+                    + std::to_string(player_pokemons.at(player_index)->getCurrentHp()) + "/" 
+                    + std::to_string(player_pokemons.at(player_index)->getBaseHp()) + " HP"
                 ),
                 text (
-                    "Type(s) : " + player_pokemons[player_index]->getType1()
-                    + (!player_pokemons[player_index]->getType2().empty() ? ", " + player_pokemons[player_index]->getType2() : "")
+                    "Type(s) : " + player_pokemons.at(player_index)->getType1()
+                    + (!player_pokemons.at(player_index)->getType2().empty() ? ", " + player_pokemons.at(player_index)->getType2() : "")
                 ),
                 separatorDouble(),
             });
@@ -165,15 +165,15 @@ void Fight(ftxui::ScreenInteractive& screen, Player& player, Trainer& opponent) 
             return vbox ({
                 text((is_master ? "Master " : "Gym leader ") + opponent.getName()),
                 separatorDouble(),
-                opponent_pokemons[opponent_index]->getSprite()->Render(),
+                opponent_pokemons.at(opponent_index)->getSprite()->Render(),
                 text (
-                    "Current Pokemon: " + opponent_pokemons[opponent_index]->getName() + " - "
-                    + std::to_string(opponent_pokemons[opponent_index]->getCurrentHp()) + "/" 
-                    + std::to_string(opponent_pokemons[opponent_index]->getBaseHp()) + " HP"
+                    "Current Pokemon: " + opponent_pokemons.at(opponent_index)->getName() + " - "
+                    + std::to_string(opponent_pokemons.at(opponent_index)->getCurrentHp()) + "/" 
+                    + std::to_string(opponent_pokemons.at(opponent_index)->getBaseHp()) + " HP"
                 ),
                 text (
-                    "Type(s) : " + opponent_pokemons[opponent_index]->getType1()
-                    + (!opponent_pokemons[opponent_index]->getType2().empty() ? ", " + opponent_pokemons[opponent_index]->getType2() : "")
+                    "Type(s) : " + opponent_pokemons.at(opponent_index)->getType1()
+                    + (!opponent_pokemons.at(opponent_index)->getType2().empty() ? ", " + opponent_pokemons.at(opponent_index)->getType2() : "")
                 ),
             });
         }),

--- a/src/ui/MainMenu.cpp
+++ b/src/ui/MainMenu.cpp
@@ -162,7 +162,7 @@ Component PokemonDetails(std::shared_ptr<Pokemon> p) {
 
 Component healButton(int& selected, Player& player) {
     return Button("Heal", [&] {
-        auto& selected_pokemon = player.getPokemons()[selected];
+        auto& selected_pokemon = player.getPokemons().at(selected);
         // Heal the pokemon only if needed and player has at least 1 potion
         if(selected_pokemon->getCurrentHp() < selected_pokemon->getBaseHp() 
         && player.getNbPotions() > 0) 
@@ -187,7 +187,7 @@ Component interactionBox(std::shared_ptr<Element> interaction_text) {
 
 Component pokemonInteractButton(int& selected, Player& player, std::shared_ptr<Element> interaction_text) {
     return Button("Interact", [&] {
-        auto& selected_pokemon = player.getPokemons()[selected];
+        auto& selected_pokemon = player.getPokemons().at(selected);
         *interaction_text = text(player.interactWith(selected_pokemon));
     }, ButtonOption::Animated(Color::Orange4)) | center;
 }
@@ -225,10 +225,10 @@ void mainMenu(ScreenInteractive& screen, GameState& state, Player& player,
 
             do {
                 random_index = Random::get(0, static_cast<int>(masters.size()) - 1);
-            } while (masters[random_index].isDefeated() && !defeatedAllMasters(masters));
+            } while (masters.at(random_index).isDefeated() && !defeatedAllMasters(masters));
 
             if(!defeatedAllMasters(masters)) {
-                Fight(screen, player, masters[random_index]);
+                Fight(screen, player, masters.at(random_index));
                 screen.ExitLoopClosure()();
             }
             
@@ -257,7 +257,7 @@ void mainMenu(ScreenInteractive& screen, GameState& state, Player& player,
     Component tab_content = Renderer([&] {
         return hbox({
             vbox({
-                PokemonDetails(player.getPokemons()[tab_selected])->Render(),
+                PokemonDetails(player.getPokemons().at(tab_selected))->Render(),
                 sprite->Render(),
             }),
         }); 

--- a/src/ui/SelectionMenu.cpp
+++ b/src/ui/SelectionMenu.cpp
@@ -96,7 +96,7 @@ std::vector<std::shared_ptr<Pokemon>> SelectionMenu(
             // Get the chosen pokemons
             for(size_t i {0} ; i < length ; ++i) {
                 if(states[i]) 
-                    selected_pokemons.push_back(pokemon_list[i]);
+                    selected_pokemons.push_back(pokemon_list.at(i));
             }
             
             // Free allocated memory and exit menu
@@ -108,7 +108,7 @@ std::vector<std::shared_ptr<Pokemon>> SelectionMenu(
     auto sprite = Renderer([&] {
         int i = checkbox_container->ActiveChild()->Index();
         if (0 <= i && i < pokemon_list.size()) {
-            return pokemon_list[i]->getSprite()->Render() | center;
+            return pokemon_list.at(i)->getSprite()->Render() | center;
         }
         return vbox({ text("index out of range") });
     });


### PR DESCRIPTION
This pull request replaces almost all instances (only when possible) of `[]` indexing with `.at()` in files to enhance code safety and prevent potential out-of-bounds access errors. Using `.at()` provides bounds checking and throws an exception if an out-of-range access is attempted, which is safer and more robust.

**Benefits:**
- Improved code safety by preventing out-of-bounds access.
- More predictable behavior in case of erroneous indexing.
- Easier debugging and error handling.
