### PR TITLE
Refactor colors to remove Palette16 usage

### DIFF
--- a/src/SpriteReader.cpp
+++ b/src/SpriteReader.cpp
@@ -243,8 +243,10 @@ std::vector<std::vector<Color>> convertToColorGrid(const std::vector<std::pair<s
     std::vector<std::vector<Color>> grid;
     grid.reserve(parsed.size() * 2UL);
 
-    Color fg_color = Color::Black;
-    Color bg_color = Color::Black;
+    const Color default_color = Color::RGB(0, 0, 0);
+
+    Color fg_color = default_color;
+    Color bg_color = default_color;
 
     for (const auto& line : parsed) {
         size_t colorIndex {};
@@ -267,12 +269,12 @@ std::vector<std::vector<Color>> convertToColorGrid(const std::vector<std::pair<s
                 ++colorIndex;
                 break;
             case Item::ColorReset:
-                fg_color = Color::Black;
-                bg_color = Color::Black;
+                fg_color = default_color;
+                bg_color = default_color;
                 break;
             case Item::Space:
-                upper_pixels.emplace_back(Color::Black);
-                lower_pixels.emplace_back(Color::Black);
+                upper_pixels.emplace_back(default_color);
+                lower_pixels.emplace_back(default_color);
                 break;
             case Item::UpperSquare:
                 upper_pixels.emplace_back(fg_color);

--- a/src/ui/Fight.cpp
+++ b/src/ui/Fight.cpp
@@ -44,7 +44,7 @@ Component fightHeader(const Player& player, const Trainer& opponent) {
     return Renderer([&] {
         return hbox ({
             text("Pokemon trainer " + player.getName()),
-            text(" VS ") | color(Color::Green),
+            text(" VS ") | color(Color::Green1),
             text(opponent.toString()),
         });
     });

--- a/src/ui/Introduction.cpp
+++ b/src/ui/Introduction.cpp
@@ -23,7 +23,7 @@ std::string IntroductionMenu(ScreenInteractive& screen, GameState& current_state
     Component intro_text = Renderer([&] {
         return vbox ({
             separatorEmpty(),
-            text("Welcome to the incredible world of Pokemons !") | bold | center | color(Color::BlueLight),
+            text("Welcome to the incredible world of Pokemons !") | bold | center | color(Color::SkyBlue1),
             separatorEmpty(),
             text("You will soon get started in the Kanto region") | center,
             separatorDouble(),
@@ -65,13 +65,13 @@ std::string IntroductionMenu(ScreenInteractive& screen, GameState& current_state
         } 
         else if (length > 15) {
             return vbox({
-                text("Name is too long (max 15 characters)") | center | color(Color::Red),
+                text("Name is too long (max 15 characters)") | center | color(Color::Red1),
                 separatorEmpty(),
             }) | center;
         }
         else {
             return vbox({
-                text("Seems like a valid name :)") | center | color(Color::Green),
+                text("Seems like a valid name :)") | center | color(Color::Green1),
                 separatorEmpty(),
             }) | center;
         }
@@ -84,7 +84,7 @@ std::string IntroductionMenu(ScreenInteractive& screen, GameState& current_state
             current_state = GameState::SelectionMenu;
             screen.ExitLoopClosure()();
         }
-    }, ButtonOption::Animated(Color::BlueLight));
+    }, ButtonOption::Animated(Color::SkyBlue1));
 
     Component resume = Renderer([&] {
         return hbox ({
@@ -93,9 +93,9 @@ std::string IntroductionMenu(ScreenInteractive& screen, GameState& current_state
             separatorDouble(),
             text("Badges: 0"),
             separatorDouble(),
-            text("Win(s): 0") | color(Color::Green),
+            text("Win(s): 0") | color(Color::Green1),
             separatorDouble(),
-            text("Defeat(s): 0") | color(Color::Red),
+            text("Defeat(s): 0") | color(Color::Red1),
         });
     });
 

--- a/src/ui/MainMenu.cpp
+++ b/src/ui/MainMenu.cpp
@@ -14,7 +14,7 @@ Component exitButton(ScreenInteractive& screen, GameState& state) {
     return Button(" Exit game ", [&] {
         state = GameState::Exit;
         screen.ExitLoopClosure()();
-    }, ButtonOption::Animated(Color::Red));
+    }, ButtonOption::Animated(Color::Red1));
 }
 
 Component PlayerStats(const Player& player) {
@@ -23,11 +23,11 @@ Component PlayerStats(const Player& player) {
         return hbox ({
             text(player.getName() + " "),
             separatorDouble(),
-            text(" " + std::to_string(player.getBadges()) + " badge(s) ") | color(Color::BlueLight),
+            text(" " + std::to_string(player.getBadges()) + " badge(s) ") | color(Color::SkyBlue1),
             separatorDouble(),
-            text(" " + std::to_string(player.getWins()) + " win(s) ") | color(Color::Green),
+            text(" " + std::to_string(player.getWins()) + " win(s) ") | color(Color::Green1),
             separatorDouble(),
-            text(" " + std::to_string(player.getDefeats()) + " defeat(s) ") | color(Color::Red),
+            text(" " + std::to_string(player.getDefeats()) + " defeat(s) ") | color(Color::Red1),
             separatorDouble(),
             text(" " + std::to_string(player.getNbPotions()) + " potion(s) ") | color(Color::Pink1),
         }) | center | border;
@@ -155,7 +155,7 @@ Component PokemonDetails(std::shared_ptr<Pokemon> p) {
                 text(p->getName()) | bold | center,
                 separator(),
                 ( p->getCurrentHp() == 0 )
-                ? ( hp_display | color(Color::Red) )
+                ? ( hp_display | color(Color::Red1) )
                 : ( hp_display ),
                 text("Type(s): " + p->getType1() + (p->getType2().empty() ? "" : ", " + p->getType2())),
             }) | border | center;
@@ -180,7 +180,7 @@ Component interactionBox(std::shared_ptr<Element> interaction_text) {
     return Container::Vertical({
         Renderer([&] {
             return vbox({
-                text("Interaction box") | bold | color(Color::Green) | center,
+                text("Interaction box") | bold | color(Color::Green1) | center,
                 separatorDouble(),
                 *interaction_text
             }) | border | center;

--- a/src/ui/SelectionMenu.cpp
+++ b/src/ui/SelectionMenu.cpp
@@ -74,13 +74,13 @@ std::vector<std::shared_ptr<Pokemon>> SelectionMenu(
         } 
         else if (nb_selected > 6) {
             return vbox({ 
-                text("Too many Pokemons selected (" + std::to_string(nb_selected) + ")") | center | bgcolor(Color::Red),
+                text("Too many Pokemons selected (" + std::to_string(nb_selected) + ")") | center | bgcolor(Color::Red1),
                 separator(),
             });
         } 
         else {
             return vbox({ 
-                text("Good") | center | bgcolor(Color::Green),
+                text("Good") | center | bgcolor(Color::Green1),
                 separator(),
             }) ;
         }

--- a/src/ui/StartMenu.cpp
+++ b/src/ui/StartMenu.cpp
@@ -23,13 +23,13 @@ GameState StartMenu(ScreenInteractive& screen)
     Component subhead = Renderer([&]{
         return vbox ({
             separatorEmpty(),
-            text("Welcome to Pokemonpp, a C++ Pokemon battle simulation") | center | bold | color(Color::BlueLight),
+            text("Welcome to Pokemonpp, a C++ Pokemon battle simulation") | center | bold | color(Color::SkyBlue1),
             separatorEmpty(),
         });
     });
 
-    auto style = ButtonOption::Animated(Color::Default, Color::GrayDark,
-                                        Color::Default, Color::White);
+    auto style = ButtonOption::Animated(Color::Default, Color::DarkSlateGray1,
+                                        Color::Default, Color::RGB(255, 255, 255));
 
     Component selection = Container::Horizontal({
         Button("Start", [&] {current_state = GameState::Introduction; screen.ExitLoopClosure()();}, style) | center,


### PR DESCRIPTION
This PR refactors the existing code to remove the usage of Palette16 colors. The changes ensure that the application adheres to a consistent and desired color palette, avoiding issues where most terminals have customized Palette16 colors.

**Changes:**
- Updated color references to use a consistent color palette instead of Palette16.
- Removed all instances of Palette16 colors throughout the codebase.

**Testing:**
- Confirmed that the UI displays the correct colors as per the desired palette.