### PR TITLE
Fix Main Menu Crash and Refactor Interaction Text Handling

### DIFF
--- a/include/ui/MainMenu.h
+++ b/include/ui/MainMenu.h
@@ -9,7 +9,7 @@
 
 ftxui::Component exitButton(ftxui::ScreenInteractive& screen, GameState& state);
 ftxui::Component PlayerStats(const Player& player);
-ftxui::Component leaderEntry(ftxui::ScreenInteractive& screen, GymLeader& leader, Player& player, GameState& state, std::shared_ptr<ftxui::Element> interaction_text);
+ftxui::Component leaderEntry(ftxui::ScreenInteractive& screen, GymLeader& leader, Player& player, GameState& state);
 ftxui::Component Title(const Player& player, const std::vector<GymLeader>& leaders);
 ftxui::Component movePokemonContainer(std::vector<std::string>& values, std::vector<std::string>& entries, Player& player, int& selected);
 ftxui::Component PokemonDetails(std::shared_ptr<Pokemon> p);


### PR DESCRIPTION
This pull request addresses and fixes a crash in the Main Menu by refactoring the interaction text handling. The changes include:

- **Refactored Interaction Text Handling:**
  - Removed the use of shared pointers for interaction text and made it a static variable.
  - Updated functions to no longer require a shared pointer to interaction text.
  - Simplified the `interactionBox` component.

- **Specific Changes:**
  - Moved `interaction_text` to a static variable in `MainMenu.cpp`.
  - Updated `leaderInteractButton` and `leaderEntry` functions to no longer accept a shared pointer for interaction text.
  - Simplified the `interactionBox` component by using a static interaction text variable.
  - Updated `pokemonInteractButton` to no longer accept a shared pointer for interaction text.

These changes improve the code structure and should resolve the crash issue in the Main Menu.

### Testing
- The changes have been tested locally to ensure that the Main Menu no longer crashes and that the interaction text updates correctly.
