### PR TITLE
End Menu and Victory/Defeat Handling

### DIFF
--- a/include/FightUtils.h
+++ b/include/FightUtils.h
@@ -10,5 +10,7 @@ void resetPokemonHp(const std::vector<std::shared_ptr<Pokemon>>& pokemon_list);
 float getDamagesMultiplicator(std::shared_ptr<Pokemon>& src, std::shared_ptr<Pokemon>& target);
 bool defeatedAllGym(const std::vector<GymLeader>& leaders);
 bool defeatedAllMasters(const std::vector<Master>& masters);
+bool isVictory(const std::vector<GymLeader>& leaders, const std::vector<Master>& masters);
+bool isDefeat(const Player& player);
 
 #endif

--- a/include/Trainer.h
+++ b/include/Trainer.h
@@ -22,6 +22,7 @@ public:
     // pure virtual function
     virtual const std::string toString() const = 0;
     virtual void Defeated() = 0;
+    virtual void setDefeated(const bool new_defeated) = 0;
 
     const std::vector<std::shared_ptr<Pokemon>>& getPokemons() const;
     const std::string& getName() const;
@@ -55,6 +56,7 @@ public:
 
     void swapPokemons(int index1, int index2);
     void Defeated() override;
+    void setDefeated(const bool new_defeated) override;
 
     const std::string interactWith(const std::shared_ptr<Interact>& target);
 };
@@ -76,6 +78,7 @@ public:
     int getBadgesCondition() const;
     bool isDefeated() const;
     void Defeated() override;
+    void setDefeated(const bool new_defeated) override;
     const std::string interactWith() const override;
 };
 
@@ -89,6 +92,7 @@ public:
     const std::string toString() const override;
     bool isDefeated() const;
     void Defeated() override;
+    void setDefeated(const bool new_defeated) override;
 };
 
 #endif

--- a/include/ui/EndMenu.h
+++ b/include/ui/EndMenu.h
@@ -1,0 +1,11 @@
+#ifndef END_MENU_H
+#define END_MENU_H
+
+#include "Game.h"
+#include "ftxui/component/screen_interactive.hpp"
+
+#include <string>
+
+GameState EndMenu(ftxui::ScreenInteractive& screen, const bool victory);
+
+#endif // END_MENU_H

--- a/include/ui/Game.h
+++ b/include/ui/Game.h
@@ -10,6 +10,7 @@ enum class GameState {
     SelectionMenu,
     Credits,
     Exit,
+    EndMenu,
 };
 
 void runGame();

--- a/include/ui/MainMenu.h
+++ b/include/ui/MainMenu.h
@@ -17,7 +17,7 @@ ftxui::Component healButton(int& selected, Player& player);
 
 void updatePokemonsEntries(std::vector<std::string>& values, std::vector<std::string>& entries, Player& player);
 
-void mainMenu(ftxui::ScreenInteractive& screen, GameState& state, Player& player, 
+bool mainMenu(ftxui::ScreenInteractive& screen, GameState& state, Player& player,
             std::vector<GymLeader>& leaders, 
             std::vector<Master>& masters);
 

--- a/src/FightUtils.cpp
+++ b/src/FightUtils.cpp
@@ -67,3 +67,11 @@ bool defeatedAllMasters(const std::vector<Master>& masters) {
 
     return true;
 }
+
+bool isVictory(const std::vector<GymLeader>& leaders, const std::vector<Master>& masters) {
+    return defeatedAllGym(leaders) && defeatedAllMasters(masters);
+}
+
+bool isDefeat(const Player& player) {
+    return allPokemonsKO(player.getPokemons()) && player.getNbPotions() == 0;
+}

--- a/src/Trainer.cpp
+++ b/src/Trainer.cpp
@@ -46,6 +46,7 @@ void Player::swapPokemons(int index1, int index2) {
 }
 
 void Player::Defeated() { setDefeats(getDefeats() + 1); }
+void Player::setDefeated(const bool new_defeated) { if (new_defeated) Defeated(); }
 
 const std::string Player::interactWith(const std::shared_ptr<Interact>& target) {
     return target->interactWith();
@@ -72,6 +73,7 @@ const std::string& GymLeader::getGymName() const { return gym_name; }
 int GymLeader::getBadgesCondition() const { return badges_condition; }
 bool GymLeader::isDefeated() const { return defeated; }
 void GymLeader::Defeated() { defeated = true; }
+void GymLeader::setDefeated(const bool new_defeated) { defeated = new_defeated; }
 
 const std::string GymLeader::interactWith() const {
     return name + ": Félicitations ! Tu as prouvé ta force et ta détermination. Continue comme ça et tu deviendras un véritable maître Pokemon !";
@@ -92,3 +94,4 @@ const std::string Master::toString() const
 
 bool Master::isDefeated() const { return defeated; }
 void Master::Defeated() { defeated = true; }
+void Master::setDefeated(const bool new_defeated) { defeated = new_defeated; }

--- a/src/ui/EndMenu.cpp
+++ b/src/ui/EndMenu.cpp
@@ -1,0 +1,54 @@
+#include "EndMenu.h"
+#include "Game.h"
+
+#include "ftxui/component/screen_interactive.hpp"
+#include "ftxui/component/component.hpp"
+#include "ftxui/dom/elements.hpp"
+
+using namespace ftxui;
+
+GameState EndMenu(ScreenInteractive& screen, const bool victory)
+{
+    GameState current_state { GameState::StartMenu };
+
+    Component victory_text = Renderer([] {
+        return vbox ({
+            text(R"(  _   ___     __               )") | color(Color::Green1) | center,
+            text(R"( | | / (_)___/ /____  ______ __)") | color(Color::Green1) | center,
+            text(R"( | |/ / / __/ __/ _ \/ __/ // /)") | color(Color::Green1) | center,
+            text(R"( |___/_/\__/\__/\___/_/  \_, / )") | color(Color::Green1) | center,
+            text(R"(                        /___/  )") | color(Color::Green1) | center,
+            separatorEmpty(),
+            text("You won the game! You can play again or exit.") | center | bold | color(Color::SkyBlue1),
+        });
+    });
+
+    Component game_over_text = Renderer([] {
+        return vbox ({
+            text(R"(   _____                 ____              )") | color(Color::Red1) | center,
+            text(R"(  / ___/__ ___ _  ___   / __ \_  _____ ____)") | color(Color::Red1) | center,
+            text(R"( / (_ / _ `/  ' \/ -_) / /_/ / |/ / -_) __/)") | color(Color::Red1) | center,
+            text(R"( \___/\_,_/_/_/_/\__/  \____/|___/\__/_/   )") | color(Color::Red1) | center,
+            separatorEmpty(),
+            text("Game is over! You can play again or exit.") | center | bold | color(Color::SkyBlue1),
+        });
+    });
+
+    auto style = ButtonOption::Animated(Color::Default, Color::DarkSlateGray1,
+                                        Color::Default, Color::RGB(255, 255, 255));
+
+    Component selection = Container::Horizontal({
+        Button("Play again", [&] {current_state = GameState::SelectionMenu; screen.ExitLoopClosure()();}, style) | center,
+        Renderer([] { return separatorDouble(); }),
+        Button("Exit", [&] {current_state = GameState::Exit; screen.ExitLoopClosure()();}, style) | center,
+    });
+
+    auto start_menu = Container::Vertical({
+        victory ? victory_text : game_over_text,
+        selection | center,
+    }) | center | bgcolor(Color::RGB(0, 0, 0));
+
+    screen.Loop(start_menu);
+
+    return current_state;
+}

--- a/src/ui/MainMenu.cpp
+++ b/src/ui/MainMenu.cpp
@@ -193,10 +193,12 @@ Component pokemonInteractButton(int& selected, Player& player) {
     }, ButtonOption::Animated(Color::Orange4)) | center;
 }
 
-void mainMenu(ScreenInteractive& screen, GameState& state, Player& player, 
+bool mainMenu(ScreenInteractive& screen, GameState& state, Player& player,
     std::vector<GymLeader>& leaders, 
     std::vector<Master>& masters)
 {
+    interaction_text = text("");
+
     Component header            { PlayerStats(player) };
     Component title             { Title(player, leaders) };
     Component leaders_display   { Container::Vertical({}) };
@@ -304,5 +306,16 @@ void mainMenu(ScreenInteractive& screen, GameState& state, Player& player,
         }) | center | bgcolor(Color::RGB(0, 0, 0));
     }
 
+    if (isVictory(leaders, masters)) {
+        state = GameState::EndMenu;
+        return true;
+    }
+    if (isDefeat(player)) {
+        state = GameState::EndMenu;
+        return false;
+    }
+
     screen.Loop(render);
+
+    return false;
 }


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the game:

- **Added EndMenu Component**: A new component that displays an end screen with victory or game over messages and options to play again or exit.
- **Victory and Defeat Handling**: Modified the main menu to handle victory and defeat scenarios. The game now checks if the player has defeated all GymLeaders and Masters or if the player is defeated due to all Pokemons being KO and no remaining potions.
- **Reset Game State**: Added a function `resetToGameStart` to reset the game state when transitioning back to the start menu after an end game scenario.
- **Enhancements to Trainer Subclasses**: Added `setDefeated` methods to `Player`, `GymLeader`, and `Master` classes to set the defeated status.
- **Utility Functions**: Added `isVictory` and `isDefeat` functions to `FightUtils` to determine the game's victory or defeat status.

### Key Changes:
- **`include/FightUtils.h` and `src/FightUtils.cpp`**: Added utility functions `isVictory` and `isDefeat`.
- **`include/Trainer.h` and `src/Trainer.cpp`**: Added `setDefeated` method to `Trainer` subclasses.
- **`include/ui/EndMenu.h` and `src/ui/EndMenu.cpp`**: Added new `EndMenu` component.
- **`include/ui/Game.h` and `src/ui/Game.cpp`**: Added `EndMenu` state and `resetToGameStart` function.
- **`include/ui/MainMenu.h` and `src/ui/MainMenu.cpp`**: Modified `mainMenu` to handle victory and defeat.

### Testing:
- Verified that the game transitions correctly to the end menu upon victory or defeat.
- Ensured that the game state is reset properly when transitioning back to the start menu.

This PR should enhance the game experience by providing clear end game scenarios and ensuring consistent game state management.
